### PR TITLE
Release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,8 @@
 # Changelog
+
+## 0.1.0 (Pre Release)
+  - First release of CCS Prototype Kit Model Interface.
+    This package can be integrated with GOV.UK Prototype Kit adding features such as:
+    - Models
+    - Validations
+    - A data structure and interface to work with the prototype

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccs-prototype-kit-model-interface",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "An interface for the ccs-prototype-kit to allow for the use of a pseudo database and models",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
First release of CCS Prototype Kit Model Interface.
This package can be integrated with GOV.UK Prototype Kit adding features such as:
- Models
- Validations
- A data structure and interface to work with the prototype