### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.0 (Pre Release)
+  - When assigning attributes, you can now pass arrays [#PR 10](https://github.com/tim-s-ccs/ccs-prototype-kit-model-interface/pull/10)
+
 ## 0.1.1 (Pre Release)
   - While adding tests to the framework, a bug was found in `formatDate` which was fixed
 ## 0.1.0 (Pre Release)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccs-prototype-kit-model-interface",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ccs-prototype-kit-model-interface",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccs-prototype-kit-model-interface",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "An interface for the ccs-prototype-kit to allow for the use of a pseudo database and models",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
When assigning attributes, you can now pass arrays [#PR 10](https://github.com/tim-s-ccs/ccs-prototype-kit-model-interface/pull/10)