### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.3.0 (Pre Release)
+  - There are now callback functions available for active models [#PR 15](https://github.com/tim-s-ccs/ccs-prototype-kit-model-interface/pull/15)
+
 ## 0.2.1 (Pre Release)
   - Small update to improve the cast method [#PR 12](https://github.com/tim-s-ccs/ccs-prototype-kit-model-interface/pull/12)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccs-prototype-kit-model-interface",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ccs-prototype-kit-model-interface",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccs-prototype-kit-model-interface",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "An interface for the ccs-prototype-kit to allow for the use of a pseudo database and models",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
There are now callback functions available for active models [#PR 15](https://github.com/tim-s-ccs/ccs-prototype-kit-model-interface/pull/15)