### PR TITLE
Make request an attribute on active model

### DIFF
--- a/src/types/models/model.ts
+++ b/src/types/models/model.ts
@@ -8,6 +8,7 @@ export interface ModelInterface {
 }
 
 export interface ActiveModelInterface {
+  req: Request
   data: ActiveModelData
   tableName: string
   modelSchema: ModelSchema
@@ -18,8 +19,8 @@ export interface ActiveModelInterface {
   errorList(): Array<ListError>
   attributes(): TableRow
   assignAttributes(date: ActiveModelData): void
-  save(req: Request, call: string): boolean
-  create(req: Request): boolean
+  save(call: string): boolean
+  create(): boolean
 }
 
 export interface StaticModelInterface {


### PR DESCRIPTION
As the request object is the same, we can save it as an attribute on the `ActiveModel`. This way when we save we don't need to pass about the request object when saving and creating.