### PR TITLE
Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 0.7.0 (Pre Release)
+  - Add the ability to create new models while saving models [#PR 30](https://github.com/tim-s-ccs/ccs-prototype-kit-model-interface/pull/30)
+  - Add the ability to save when there is an array of models [#PR 31](https://github.com/tim-s-ccs/ccs-prototype-kit-model-interface/pull/31)
+  - Change IDs so they are strings for both static and active models [#PR 31](https://github.com/tim-s-ccs/ccs-prototype-kit-model-interface/pull/31) & [#PR 32](https://github.com/tim-s-ccs/ccs-prototype-kit-model-interface/pull/32)
+
 ## 0.6.0 (Pre Release)
   - Add the `Request` object as an attribute on the active model [#PR 28](https://github.com/tim-s-ccs/ccs-prototype-kit-model-interface/pull/28)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccs-prototype-kit-model-interface",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ccs-prototype-kit-model-interface",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccs-prototype-kit-model-interface",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "An interface for the ccs-prototype-kit to allow for the use of a pseudo database and models",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
- Add the ability to create new models while saving models [#PR 30](https://github.com/tim-s-ccs/ccs-prototype-kit-model-interface/pull/30)
- Add the ability to save when there is an array of models [#PR 31](https://github.com/tim-s-ccs/ccs-prototype-kit-model-interface/pull/31)
- Change IDs so they are strings for both static and active models [#PR 31](https://github.com/tim-s-ccs/ccs-prototype-kit-model-interface/pull/31) & [#PR 32](https://github.com/tim-s-ccs/ccs-prototype-kit-model-interface/pull/32)

